### PR TITLE
[WIP] JMS Serializer Bundle Integration

### DIFF
--- a/Annotation/FormType.php
+++ b/Annotation/FormType.php
@@ -28,29 +28,16 @@ class FormType
      */
     private $type;
 
-    /**
-     * @var string
-     */
-    private $group = 'default';
-
     public function __construct(array $values)
     {
         if (isset($values['value'])) {
             $this->type = $values['value'];
-        }
-        if (isset($values['group'])) {
-            $this->group = $values['group'];
         }
     }
 
     public function getType()
     {
         return $this->type;
-    }
-
-    public function getGroup()
-    {
-        return $this->group;
     }
 }
 

--- a/Annotation/FormType.php
+++ b/Annotation/FormType.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SimpleThings FormSerializerBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormSerializerBundle\Annotation;
+
+/**
+ * Register form type that is responsible for serializing the annotated entity.
+ *
+ * @Annotation
+ * @Target("CLASS")
+ */
+class FormType
+{
+    /**
+     * Class or form-type name that is registered in Form Factory.
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $group = 'default';
+
+    public function __construct(array $values)
+    {
+        if (isset($values['value'])) {
+            $this->type = $values['value'];
+        }
+        if (isset($values['group'])) {
+            $this->group = $values['group'];
+        }
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getGroup()
+    {
+        return $this->group;
+    }
+}
+

--- a/Serializer/FormSerializer.php
+++ b/Serializer/FormSerializer.php
@@ -71,8 +71,8 @@ class FormSerializer implements FormSerializerInterface
         if (($typeBuilder instanceof FormTypeInterface) || is_string($typeBuilder)) {
             $form = $this->factory->create($typeBuilder, $object);
         } else if ($typeBuilder instanceof FormBuilderInterface) {
+            $typeBuilder->setData($object);
             $form = $typeBuilder->getForm();
-            $form->setData($object);
         } else if ($typeBuilder instanceof FormInterface) {
             $form = $typeBuilder;
             if ( ! $form->isBound()) {

--- a/Serializer/JMS/FormMetadataDriver.php
+++ b/Serializer/JMS/FormMetadataDriver.php
@@ -49,7 +49,7 @@ class FormMetadataDriver implements DriverInterface
                     $propertyMetadata = new PropertyMetadata($name, $property->getName());
                     #$propertyMetadata->setAccessor('public_method', null, null);
 
-                    if ( !empty($childOptions['serialize_name'])) {
+                    if (!empty($childOptions['serialize_name'])) {
                         $propertyMetadata->serializedName = $childOptions['serialize_name'];
                     }
 
@@ -82,7 +82,6 @@ class FormMetadataDriver implements DriverInterface
                         $propertyMetadata->readOnly = true;
                     }
 
-                    #var_dump($propertyMetadata);
                     $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }
@@ -105,9 +104,11 @@ class FormMetadataDriver implements DriverInterface
             case 'birthday';
                 return 'DateTime';
             case 'number':
-                return 'float';
+                return 'double';
             case 'checkbox':
                 return 'boolean';
+            case 'integer';
+                return 'integer';
             default:
                 return 'string';
         }

--- a/Serializer/JMS/FormMetadataDriver.php
+++ b/Serializer/JMS/FormMetadataDriver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SimpleThings\FormSerializerBundle\Serializer\JMS;
+
+use JMS\SerializerBundle\Metadata\ClassMetadata;
+use JMS\SerializerBundle\Metadata\PropertyMetadata;
+use JMS\SerializerBundle\Metadata\VirtualPropertyMetadata;
+
+use SimpleThings\FormSerializerBundle\Annotation\FormType;
+
+use Metadata\Driver\DriverInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Doctrine\Common\Annotations\Reader;
+
+class FormMetadataDriver implements DriverInterface
+{
+    private $reader;
+    private $formFactory;
+
+    public function __construct(Reader $reader, FormFactoryInterface $formFactory)
+    {
+        $this->reader      = $reader;
+        $this->formFactory = $formFactory;
+    }
+
+    public function loadMetadataForClass(\ReflectionClass $class)
+    {
+        $classMetadata = new ClassMetadata($name = $class->getName());
+
+        foreach ($this->reader->getClassAnnotations($class) as $annot) {
+            if ($annot instanceof FormType) {
+                $type  = $annot->getType();
+                $group = $annot->getGroup();
+
+                if (class_exists($type)) {
+                    $type = new $type;
+                }
+
+                $form    = $this->formFactory->create($type, null, array());
+                $options = $form->getConfig()->getOptions();
+
+                $classMetadata->xmlRootName = $options['serialize_xml_name'];
+
+                $propertiesMetadata = array();
+                foreach ($form->getChildren() as $children) {
+                    $childOptions = $children->getConfig()->getOptions();
+
+                    $property         = $class->getProperty($children->getName());
+                    $propertyMetadata = new PropertyMetadata($name, $property->getName());
+
+                    var_dump($propertyMetadata);
+                }
+            }
+        }
+
+        return $classMetadata;
+    }
+}
+

--- a/Serializer/JMS/FormMetadataDriver.php
+++ b/Serializer/JMS/FormMetadataDriver.php
@@ -30,7 +30,6 @@ class FormMetadataDriver implements DriverInterface
         foreach ($this->reader->getClassAnnotations($class) as $annot) {
             if ($annot instanceof FormType) {
                 $type  = $annot->getType();
-                $group = $annot->getGroup();
 
                 if (class_exists($type)) {
                     $type = new $type;
@@ -44,16 +43,74 @@ class FormMetadataDriver implements DriverInterface
                 $propertiesMetadata = array();
                 foreach ($form->getChildren() as $children) {
                     $childOptions = $children->getConfig()->getOptions();
+                    $type = $children->getConfig()->getType();
 
                     $property         = $class->getProperty($children->getName());
                     $propertyMetadata = new PropertyMetadata($name, $property->getName());
+                    #$propertyMetadata->setAccessor('public_method', null, null);
 
-                    var_dump($propertyMetadata);
+                    if ( !empty($childOptions['serialize_name'])) {
+                        $propertyMetadata->serializedName = $childOptions['serialize_name'];
+                    }
+
+                    if ($type->getName() == "collection") {
+                        $propertyMetadata->xmlCollection = true;
+                        $propertyMetadata->xmlCollectionInline = $childOptions['serialize_xml_inline'];
+
+                        if ( ! empty($childOptions['serialize_xml_name'])) {
+                            $propertyMetadata->xmlEntryName = $childOptions['serialize_xml_name'];
+                        }
+
+                        $subForm = $this->formFactory->create($childOptions['type']);
+
+                        $propertyMetadata->type = sprintf('array<%s>', $this->translateType($subForm));
+                    } else if ($type->getName() == "choice") {
+                        $propertyMetadata->type = $childOptions['multiple'] ? "array<string>" : "string";
+                    } else if ($type->getName() == "entity") {
+                        $propertyMetadata->type = $childOptions['multiple'] ? "array<string>" : "string";
+                    } else {
+                        $propertyMetadata->type = $this->translateType($children);
+                    }
+
+                    if ($childOptions['serialize_xml_attribute']) {
+                        $propertyMetadata->xmlAttribute = true;
+                    } else if ($childOptions['serialize_xml_value']) {
+                        $propertyMetadata->xmlValue = true;
+                    }
+
+                    if ($childOptions['disabled']) {
+                        $propertyMetadata->readOnly = true;
+                    }
+
+                    #var_dump($propertyMetadata);
+                    $classMetadata->addPropertyMetadata($propertyMetadata);
                 }
             }
         }
 
         return $classMetadata;
+    }
+
+    private function translateType($form)
+    {
+        $options = $form->getConfig()->getOptions();
+        if ($options['data_class']) {
+            return $options['data_class'];
+        }
+
+        switch ($form->getConfig()->getType()->getName()) {
+            case 'date':
+            case 'datetime':
+            case 'time':
+            case 'birthday';
+                return 'DateTime';
+            case 'number':
+                return 'float';
+            case 'checkbox':
+                return 'boolean';
+            default:
+                return 'string';
+        }
     }
 }
 

--- a/Tests/Serializer/Fixture/Address.php
+++ b/Tests/Serializer/Fixture/Address.php
@@ -2,9 +2,11 @@
 namespace SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture;
 
 use JMS\SerializerBundle\Annotation as JMS;
+use SimpleThings\FormSerializerBundle\Annotation\FormType;
 
 /**
  * @JMS\ExclusionPolicy("none")
+ * @FormType("SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\AddressType")
  */
 class Address
 {

--- a/Tests/Serializer/Fixture/User.php
+++ b/Tests/Serializer/Fixture/User.php
@@ -3,9 +3,11 @@
 namespace SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture;
 
 use JMS\SerializerBundle\Annotation as JMS;
+use SimpleThings\FormSerializerBundle\Annotation\FormType;
 
 /**
  * @JMS\ExclusionPolicy("none")
+ * @FormType("SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\UserType")
  */
 class User
 {

--- a/Tests/Serializer/JmsFormMetadataDriverTest.php
+++ b/Tests/Serializer/JmsFormMetadataDriverTest.php
@@ -20,7 +20,8 @@ class JmsFormMetadataDriverTest extends TestCase
         $reflClass = new \ReflectionClass('SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\User');
         $metadata  = $driver->loadMetadataForClass($reflClass);
 
-        var_dump($metadata);
+        $this->assertInstanceOf('JMS\SerializerBundle\Metadata\ClassMetadata', $metadata);
+        $this->assertEquals(array('username', 'email', 'birthday', 'country', 'address', 'addresses'), array_keys($metadata->propertyMetadata));
     }
 
     public function testSerialize()
@@ -40,10 +41,33 @@ class JmsFormMetadataDriverTest extends TestCase
         $user->interests = array('sport', 'reading');
         $user->country   = "DE";
         $user->address   = $address;
+        $user->addresses = array($address, $address);
 
         $xml = $serializer->serialize($user, 'xml');
 
-        var_dump($xml);
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<user>
+  <username><![CDATA[beberlei]]></username>
+  <email><![CDATA[kontakt@beberlei.de]]></email>
+  <birthday>1984-03-18T00:00:00+0100</birthday>
+  <country><![CDATA[DE]]></country>
+  <address street="Somestreet 1" zip_code="12345" city="Bonn"/>
+  <addresses>
+    <address street="Somestreet 1" zip_code="12345" city="Bonn"/>
+    <address street="Somestreet 1" zip_code="12345" city="Bonn"/>
+  </addresses>
+</user>
+
+XML
+            , $xml);
+
+        $json = $serializer->serialize($user, 'json');
+
+        $this->assertEquals(<<<JSON
+{"username":"beberlei","email":"kontakt@beberlei.de","birthday":"1984-03-18T00:00:00+0100","country":"DE","address":{"street":"Somestreet 1","zip_code":12345,"city":"Bonn"},"addresses":[{"street":"Somestreet 1","zip_code":12345,"city":"Bonn"},{"street":"Somestreet 1","zip_code":12345,"city":"Bonn"}]}
+JSON
+            , $json);
     }
 }
 

--- a/Tests/Serializer/JmsFormMetadataDriverTest.php
+++ b/Tests/Serializer/JmsFormMetadataDriverTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SimpleThings\FormSerializerBundle\Tests\Serializer;
+
+use SimpleThings\FormSerializerBundle\Tests\TestCase;
+use SimpleThings\FormSerializerBundle\Serializer\JMS\FormMetadataDriver;
+
+class JmsFormMetadataDriverTest extends TestCase
+{
+    public function testLoadMetadata()
+    {
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        $driver = new FormMetadataDriver($reader, $this->createFormFactory());
+
+        $reflClass = new \ReflectionClass('SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\User');
+        $metadata  = $driver->loadMetadataForClass($reflClass);
+
+        var_dump($metadata);
+    }
+}
+

--- a/Tests/Serializer/JmsFormMetadataDriverTest.php
+++ b/Tests/Serializer/JmsFormMetadataDriverTest.php
@@ -5,6 +5,11 @@ namespace SimpleThings\FormSerializerBundle\Tests\Serializer;
 use SimpleThings\FormSerializerBundle\Tests\TestCase;
 use SimpleThings\FormSerializerBundle\Serializer\JMS\FormMetadataDriver;
 
+use SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\User;
+use SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\Address;
+use SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\UserType;
+use SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\AddressType;
+
 class JmsFormMetadataDriverTest extends TestCase
 {
     public function testLoadMetadata()
@@ -16,6 +21,29 @@ class JmsFormMetadataDriverTest extends TestCase
         $metadata  = $driver->loadMetadataForClass($reflClass);
 
         var_dump($metadata);
+    }
+
+    public function testSerialize()
+    {
+        $serializer = $this->createJmsSerializer(true);
+
+        $address          = new Address();
+        $address->street  = "Somestreet 1";
+        $address->zipCode = 12345;
+        $address->city    = "Bonn";
+
+        $user            = new User();
+        $user->username  = "beberlei";
+        $user->email     = "kontakt@beberlei.de";
+        $user->birthday  = new \DateTime("1984-03-18");
+        $user->gender    = 'male';
+        $user->interests = array('sport', 'reading');
+        $user->country   = "DE";
+        $user->address   = $address;
+
+        $xml = $serializer->serialize($user, 'xml');
+
+        var_dump($xml);
     }
 }
 

--- a/Tests/Serializer/PerformanceTest.php
+++ b/Tests/Serializer/PerformanceTest.php
@@ -42,6 +42,7 @@ class PerformanceTest extends TestCase
         #echo $this->formatXml($xml);
 
         $jmsSerializer = $this->createJmsSerializer();
+        $xml = $jmsSerializer->serialize($list, 'xml');
         $start = microtime(true);
         $xml = $jmsSerializer->serialize($list, 'xml');
         echo "JMS Annotations: " . number_format(microtime(true) - $start, 4) . "\n";
@@ -49,6 +50,7 @@ class PerformanceTest extends TestCase
         #echo $this->formatXml($xml);
 
         $jmsSerializer = $this->createJmsSerializer(true);
+        $xml = $jmsSerializer->serialize($list, 'xml');
         $start = microtime(true);
         $xml = $jmsSerializer->serialize($list, 'xml');
         echo "JMS with Form Metadata: " . number_format(microtime(true) - $start, 4) . "\n";

--- a/Tests/Serializer/PerformanceTest.php
+++ b/Tests/Serializer/PerformanceTest.php
@@ -37,16 +37,21 @@ class PerformanceTest extends TestCase
 
         $start = microtime(true);
         $xml = $formSerializer->serializeList($list, new UserType(), 'xml', 'users');
-        echo number_format(microtime(true) - $start, 4) . "\n";
+        echo "Form Serializer: " . number_format(microtime(true) - $start, 4) . "\n";
 
         #echo $this->formatXml($xml);
 
         $jmsSerializer = $this->createJmsSerializer();
         $start = microtime(true);
         $xml = $jmsSerializer->serialize($list, 'xml');
-        echo number_format(microtime(true) - $start, 4) . "\n";
+        echo "JMS Annotations: " . number_format(microtime(true) - $start, 4) . "\n";
 
         #echo $this->formatXml($xml);
+
+        $jmsSerializer = $this->createJmsSerializer(true);
+        $start = microtime(true);
+        $xml = $jmsSerializer->serialize($list, 'xml');
+        echo "JMS with Form Metadata: " . number_format(microtime(true) - $start, 4) . "\n";
     }
 }
 

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -59,7 +59,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         return $formSerializer;
     }
 
-    public function createJmsSerializer()
+    public function createJmsSerializer($forms = false)
     {
         $namingStrategy    = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
         $objectConstructor = new UnserializeObjectConstructor();
@@ -83,19 +83,26 @@ class TestCase extends \PHPUnit_Framework_TestCase
             'xml'  => new XmlDeserializationVisitor($namingStrategy, $customDeserializationHandlers, $objectConstructor),
         );
 
-        $factory = $this->createJmsMetadataFactory();
+        $factory = $this->createJmsMetadataFactory($forms);
         return new JMSSerializer($factory, $serializationVisitors, $deserializationVisitors);
     }
 
-    public function createJmsMetadataFactory()
+    public function createJmsMetadataFactory($forms = false)
     {
         $fileLocator = new \Metadata\Driver\FileLocator(array());
-        $driver      = new \Metadata\Driver\DriverChain(array(
-            new \JMS\SerializerBundle\Metadata\Driver\YamlDriver($fileLocator),
-            new \JMS\SerializerBundle\Metadata\Driver\XmlDriver($fileLocator),
-            new \JMS\SerializerBundle\Metadata\Driver\PhpDriver($fileLocator),
-            new \JMS\SerializerBundle\Metadata\Driver\AnnotationDriver(new \Doctrine\Common\Annotations\AnnotationReader())
-        ));
+        if ($forms) {
+            $driver = new \SimpleThings\FormSerializerBundle\Serializer\JMS\FormMetadataDriver(
+                new \Doctrine\Common\Annotations\AnnotationReader(),
+                $this->createFormFactory()
+            );
+        } else {
+            $driver      = new \Metadata\Driver\DriverChain(array(
+                new \JMS\SerializerBundle\Metadata\Driver\YamlDriver($fileLocator),
+                new \JMS\SerializerBundle\Metadata\Driver\XmlDriver($fileLocator),
+                new \JMS\SerializerBundle\Metadata\Driver\PhpDriver($fileLocator),
+                new \JMS\SerializerBundle\Metadata\Driver\AnnotationDriver(new \Doctrine\Common\Annotations\AnnotationReader())
+            ));
+        }
         return new MetadataFactory($driver);
     }
 

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -175,7 +175,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
                     }
                 default:
                     $new_json .= $char;
-                    break;                   
+                    break;
             }
         }
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -9,7 +9,7 @@ EOT
     );
 }
 
-spl_autoload_register(function($class) {
+$bundleLoader = (function($class) {
     if (0 === strpos($class, 'SimpleThings\\FormSerializerBundle\\')) {
         $path = __DIR__.'/../'.implode('/', array_slice(explode('\\', $class), 2)).'.php';
         if (!stream_resolve_include_path($path)) {
@@ -19,5 +19,8 @@ spl_autoload_register(function($class) {
         return true;
     }
 });
+spl_autoload_register($bundleLoader);
 
 Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+Doctrine\Common\Annotations\AnnotationRegistry::registerLoader($bundleLoader);
+

--- a/composer.lock
+++ b/composer.lock
@@ -14,8 +14,8 @@
         {
             "package": "symfony/symfony",
             "version": "dev-master",
-            "source-reference": "cbd03ec4c66567cf2bf4ea9e0e3315a522b4eeb3",
-            "commit-date": "1343635713"
+            "source-reference": "a172a812960d060cd5dd13e4dcf3b2bc4043a18f",
+            "commit-date": "1343639879"
         },
         {
             "package": "twig/twig",


### PR DESCRIPTION
The serialization performance of larger graphs with the form component is very slow. This is due to the form creating and binding of data. Compared to that JMS Serializer bundle is very fast.

We should aim at using JMS Serializer for serialization, based on Form Type Metadata. The same form type metadata is used for deserialization.

How it works:

You create a form type, then hint for a class which type it is:

```
/**
 * @FormType("SimpleThings\FormSerializerBundle\Tests\Serializer\Fixture\AddressType")
 */
class Address
{
}
```

This is a WIP, what needs to be done:
1. Normalization of data with forms is much more powerful than with JMS Serializer. Both are not compatible.
2. Property Paths in forms cannot be replicated in JMS.
3. There can potentially be many form types for one entity. This cannot be replicated with groups in JMS Serializer. We need the form serializer to build an "on demand" metadata factory for a given graph, but cachable.
4. Form "entity" type is not replicable in JMS Serializer with both multiple = true and false
