### PR TITLE
Added form validation messages translation support

### DIFF
--- a/Controller/RestFormController.php
+++ b/Controller/RestFormController.php
@@ -17,6 +17,10 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Form Controller helps implementing Restful Controllers
@@ -48,7 +52,7 @@ abstract class RestFormController extends Controller
     protected $form;
 
     /**
-     * @return SimpleThings\FormSerializerBundle\Serializer\FormSerializer
+     * @return \SimpleThings\FormSerializerBundle\Serializer\FormSerializer
      */
     protected function getFormSerializer()
     {

--- a/Controller/RestFormHelper.php
+++ b/Controller/RestFormHelper.php
@@ -17,6 +17,10 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Form trait helper implementing Restful Controllers
@@ -84,7 +88,7 @@ trait RestFormHelper
         $form   = $form ?: $this->form;
         $format = $this->getRequest()->getRequestFormat();
 
-        if ($format === "html") {
+        if ($format === 'html') {
             $variables['form'] = $form->createView();
             $variables['data'] = $form->getData();
 
@@ -119,7 +123,7 @@ trait RestFormHelper
      */
     protected function flash()
     {
-        if ($this->getRequest()->getRequestFormat() !== "html") {
+        if ($this->getRequest()->getRequestFormat() !== 'html') {
             return new FlashBag; // dummy flush-bag, to keep the fluent
         }
 
@@ -150,8 +154,8 @@ trait RestFormHelper
         $link = $this->generateUrl($routeName, $parameters, $absolute);
 
         if ($statusCode === 201 || $statusCode === 204) {
-            if ($this->getRequest()->getRequestFormat() !== "html") {
-                return new Response("", $statusCode, array("Location" => $link));
+            if ($this->getRequest()->getRequestFormat() !== 'html') {
+                return new Response('', $statusCode, array('Location' => $link));
             }
             $statusCode = 301;
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,6 +30,7 @@
         </service>
 
         <service id="simple_things_form_serializer.form_serializer" class="%simple_things_form_serializer.form_serializer.class%">
+            <argument type="service" id="translator" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="simple_things_form_serializer.serializer.encoder_registry" />
             <argument type="service" id="simple_things_form_serializer.serializer.options" />


### PR DESCRIPTION
- Small bugfix: added use Symfony\Component\HttpFoundation\Response;
- Error  key in messages array changed from 'error' to 'errors' (for compability with JMSSerializerBundle)
