### PR TITLE
Fixes issues with boolean data coming from PATCH requests

### DIFF
--- a/Form/EventListener/BindRequestListener.php
+++ b/Form/EventListener/BindRequestListener.php
@@ -113,7 +113,7 @@ class BindRequestListener implements EventSubscriberInterface
 
             // If we are PATCHing then don't fill in missing attributes with null
             $childValue = $this->unserializeForm($value, $child, $isXml, $isPatch);
-            if (!($isPatch && !$childValue)) $result[$child->getName()] = $childValue;
+            if (!($isPatch && is_null($childValue))) $result[$child->getName()] = $childValue;
         }
 
         return $result;


### PR DESCRIPTION
The line was responsible for removing keys with a boolean value of `false` from PATCH request data, which is probably not desired behaviour.
